### PR TITLE
Adapt UCI to fetch releases instead of builds and to manage different ubuntu versions

### DIFF
--- a/create_tag.sh
+++ b/create_tag.sh
@@ -6,7 +6,7 @@ UBUNTU_VERSIONS="focal jammy"
 FORMATTED_BUILD_LIST=()
 TAGS=$(git tag)
 
-echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSION[*]}"
+echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSIONS[*]}"
 for UBUNTU_VERSION in ${UBUNTU_VERSIONS}; do
     echo "INFO: Fetching releases for ${UBUNTU_VERSION}"
     RELEASE_REPO="https://cloud-images.ubuntu.com/releases/$UBUNTU_VERSION/"

--- a/create_tag.sh
+++ b/create_tag.sh
@@ -1,42 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 UBUNTU_VERSIONS="focal jammy"
-FORMATTED_BUILD_LIST=()
 TAGS=$(git tag)
 
-echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSIONS[*]}"
+echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSIONS}"
 for UBUNTU_VERSION in ${UBUNTU_VERSIONS}; do
     echo "INFO: Fetching releases for ${UBUNTU_VERSION}"
     RELEASE_REPO="https://cloud-images.ubuntu.com/releases/$UBUNTU_VERSION/"
     BUILD_LIST=$(curl -s "$RELEASE_REPO" | grep 'href="release-' | sed 's/.*href="release-\([\.0-9]\{8,10\}\).*/\1/g' | sort -V)
 
     for BUILD in ${BUILD_LIST}; do
-        if ! [[ $BUILD =~ ^[\.0-9]{8,10}$ ]]; then
+        if ! echo "$BUILD" | grep -q '^[\.0-9]\{8,10\}$'; then
             echo "ERROR: found invalid build: '${BUILD}' under url ${RELEASE_REPO}"
             exit 1
         fi
 
-        FORMATTED_BUILD="$BUILD-$UBUNTU_VERSION"
-        FORMATTED_BUILD_LIST+=("$FORMATTED_BUILD")
-        if [[ $(echo "$TAGS" | grep -c "$FORMATTED_BUILD") -gt 0 ]]; then
+        FORMATTED_BUILD="${BUILD}-${UBUNTU_VERSION}"
+        if echo "${TAGS}" | grep -q "${FORMATTED_BUILD}"; then
             echo "INFO: build ${FORMATTED_BUILD} already in tag list"
             continue
         fi
 
-        git tag $FORMATTED_BUILD
+        git tag "${FORMATTED_BUILD}"
+        git push origin "${FORMATTED_BUILD}"
         echo "INFO: added ${FORMATTED_BUILD} to tag list"
     done
 done
-
-git push origin --tags
-
-for TAG in $TAGS; do
-    if [[ $(IFS=$'\n'; echo "${FORMATTED_BUILD_LIST[*]}" | grep -c "^$TAG$") -eq 0 ]]; then
-        git tag -d "${TAG}"
-        git push --delete origin "${TAG}"
-        echo "INFO: deleted ${TAG} from tag list"
-    fi
-done
-

--- a/create_tag.sh
+++ b/create_tag.sh
@@ -8,11 +8,11 @@ TAGS=$(git tag)
 echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSIONS}"
 for UBUNTU_VERSION in ${UBUNTU_VERSIONS}; do
     echo "INFO: Fetching releases for ${UBUNTU_VERSION}"
-    RELEASE_REPO="https://cloud-images.ubuntu.com/releases/$UBUNTU_VERSION/"
-    BUILD_LIST=$(curl -s "$RELEASE_REPO" | grep 'href="release-' | sed 's/.*href="release-\([\.0-9]\{8,10\}\).*/\1/g' | sort -V)
+    RELEASE_REPO="https://cloud-images.ubuntu.com/releases/${UBUNTU_VERSION}/"
+    BUILD_LIST=$(curl -s "${RELEASE_REPO}" | grep 'href="release-' | sed 's/.*href="release-\([\.0-9]\{8,10\}\).*/\1/g' | sort -V)
 
     for BUILD in ${BUILD_LIST}; do
-        if ! echo "$BUILD" | grep -q '^[\.0-9]\{8,10\}$'; then
+        if ! echo "${BUILD}" | grep -q '^[\.0-9]\{8,10\}$'; then
             echo "ERROR: found invalid build: '${BUILD}' under url ${RELEASE_REPO}"
             exit 1
         fi

--- a/create_tag.sh
+++ b/create_tag.sh
@@ -1,34 +1,42 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-# get latest version link of 8 numeric chars beginning with 20
-BUILDS=$(curl -s https://cloud-images.ubuntu.com/focal/ | grep 'href="20' | sed 's/.*href="\([\.0-9]\{8,10\}\).*/\1/g' | sort -V)
-
+UBUNTU_VERSIONS="focal jammy"
+FORMATTED_BUILD_LIST=()
 TAGS=$(git tag)
 
-for BUILD in ${BUILDS}; do
-    if ! echo "$BUILD" | grep -q '^[\.0-9]\{8,10\}$'; then
-        echo "ERROR: found invalid build: ${BUILD} under url https://cloud-images.ubuntu.com/focal/"
-        exit 1
-    fi
+echo "INFO: Checking releases for the following ubuntu versions: ${UBUNTU_VERSION[*]}"
+for UBUNTU_VERSION in ${UBUNTU_VERSIONS}; do
+    echo "INFO: Fetching releases for ${UBUNTU_VERSION}"
+    RELEASE_REPO="https://cloud-images.ubuntu.com/releases/$UBUNTU_VERSION/"
+    BUILD_LIST=$(curl -s "$RELEASE_REPO" | grep 'href="release-' | sed 's/.*href="release-\([\.0-9]\{8,10\}\).*/\1/g' | sort -V)
 
-    if echo "${TAGS}" | grep -q "${BUILD}"; then
-        echo "INFO: build ${BUILD} already in tag list"
-        continue
-    fi
+    for BUILD in ${BUILD_LIST}; do
+        if ! [[ $BUILD =~ ^[\.0-9]{8,10}$ ]]; then
+            echo "ERROR: found invalid build: '${BUILD}' under url ${RELEASE_REPO}"
+            exit 1
+        fi
 
-    git tag "${BUILD}"
-    git push origin "${BUILD}"
-    echo "INFO: added ${BUILD} to tag list"
+        FORMATTED_BUILD="$BUILD-$UBUNTU_VERSION"
+        FORMATTED_BUILD_LIST+=("$FORMATTED_BUILD")
+        if [[ $(echo "$TAGS" | grep -c "$FORMATTED_BUILD") -gt 0 ]]; then
+            echo "INFO: build ${FORMATTED_BUILD} already in tag list"
+            continue
+        fi
+
+        git tag $FORMATTED_BUILD
+        echo "INFO: added ${FORMATTED_BUILD} to tag list"
+    done
 done
 
-for TAG in ${TAGS}; do
-    if echo "${BUILDS}" | grep -q "${TAG}"; then
-        continue
-    fi
+git push origin --tags
 
-    git tag -d "${TAG}"
-    git push --delete origin "${TAG}"
-    echo "INFO: delete ${TAG} from tag list"
+for TAG in $TAGS; do
+    if [[ $(IFS=$'\n'; echo "${FORMATTED_BUILD_LIST[*]}" | grep -c "^$TAG$") -eq 0 ]]; then
+        git tag -d "${TAG}"
+        git push --delete origin "${TAG}"
+        echo "INFO: deleted ${TAG} from tag list"
+    fi
 done
+


### PR DESCRIPTION
After merging this PR, `create_tag.sh` will be able to create tags from https://cloud-images.ubuntu.com/releases/ and also deal with different ubuntu versions, that can be added to the variable `UBUNTU_VERSIONS`. Other than that, the script is now a BASH-script instead of POSIX-compliant SH (for better legibility). This won't cause any problem as the script is run on ubuntu anyway.

Partially Implements: PSC-3249